### PR TITLE
Compile project and run tests on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             toolset: gcc
             platform_version: 22.04
             arch: x86
@@ -44,6 +44,8 @@ jobs:
       - name: Configure
         shell: pwsh
         run: cmake "--preset=ci-$("${{ matrix.os }}".split("-")[0])"
+        env:
+          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 
       - name: Build
         run: cmake --build build --config Release -j 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: seanmiddleditch/gha-setup-ninja@master
+        if: runner.os == 'Linux'
+
       - name: Install boost
         uses: MarkusJx/install-boost@v2
         id: install-boost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,22 +15,26 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2
+        id: install-boost
+        with:
+          boost_version: 1.85.0
 
       - name: Configure
-        run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+        shell: pwsh
+        run: cmake "--preset=ci-$("${{ matrix.os }}".split("-")[0])"
 
       - name: Build
-        run: |
-          cmake --build build --config Debug
+        run: cmake --build build --config Release -j 2
+
+      - name: Install
+        run: cmake --install build --config Release --prefix prefix
 
       - name: Test
-        run: |
-          cd build
-          ctest -C Debug --output-on-failure --verbose
+        working-directory: build
+        run: ctest --output-on-failure --no-tests=error -C Release -j 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            toolset: gcc
+            platform_version: 24.04
+          - os: macos-latest
+            toolset: clang
+            platform_version: 14.7
+          - os: windows-latest
+            toolset: msvc
+            platform_version: 2022
 
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +34,8 @@ jobs:
         id: install-boost
         with:
           boost_version: 1.85.0
+          toolset: ${{ matrix.toolset }}
+          platform_version: ${{ matrix.platform_version }}
 
       - name: Configure
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,17 @@ jobs:
             toolset: gcc
             platform_version: 22.04
             arch: x86
+            boost_install_dir: /tmp/boost
           - os: macos-latest
             toolset: clang
             platform_version: 14
             arch: aarch64
+            boost_install_dir: /tmp/boost
           - os: windows-latest
             toolset: msvc
             platform_version: 2022
             arch: x86
+            boost_install_dir: C:\boost
 
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +43,7 @@ jobs:
           toolset: ${{ matrix.toolset }}
           platform_version: ${{ matrix.platform_version }}
           arch: ${{ matrix.arch }}
+          boost_install_dir: ${{ matrix.boost_install_dir }}
 
       - name: Configure
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Build & Test
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build
+        run: |
+          cmake --build build --config Debug
+
+      - name: Test
+        run: |
+          cd build
+          ctest -C Debug --output-on-failure --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Configure
         shell: pwsh
-        run: cmake "--preset=ci-$("${{ matrix.os }}".split("-")[0])"
+        run: cmake --preset=ci
         env:
           BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             toolset: gcc
             platform_version: 22.04
             arch: x86

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,16 @@ jobs:
         include:
           - os: ubuntu-latest
             toolset: gcc
-            platform_version: 24.04
+            platform_version: 22.04
+            arch: x86
           - os: macos-latest
             toolset: clang
-            platform_version: 14.7
+            platform_version: 14
+            arch: aarch64
           - os: windows-latest
             toolset: msvc
             platform_version: 2022
+            arch: x86
 
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +39,7 @@ jobs:
           boost_version: 1.85.0
           toolset: ${{ matrix.toolset }}
           platform_version: ${{ matrix.platform_version }}
+          arch: ${{ matrix.arch }}
 
       - name: Configure
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ cmake-build-*
 .idea
 .vscode
 Testing
-CMakeUserPresets.json
+/CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cmake-build-*
 .idea
 .vscode
 Testing
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(POLICY CMP0167)
    cmake_policy(SET CMP0167 OLD)
 endif()
 find_package(Boost 1.82 REQUIRED)
-target_include_directories(GoalsARM INTERFACE ${Boost_INCLUDE_DIRS})
+target_include_directories(GoalsARM SYSTEM INTERFACE ${Boost_INCLUDE_DIRS})
 
 # Add library
 target_include_directories(GoalsARM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(GoalsARM VERSION 1.0.0
                  LANGUAGES CXX)
 add_library(GoalsARM INTERFACE)
 
+# Set this policy so we can use BOOST_ROOT env
+# var on CI
+cmake_policy(SET CMP0144 NEW)
 if(POLICY CMP0167)
    # This policy removes FindBoost module
    # in favour of using BoostConfig.cmake files

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,131 @@
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 14,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "cmake-pedantic",
+      "hidden": true,
+      "warnings": {
+        "dev": true,
+        "deprecated": true,
+        "uninitialized": true,
+        "unusedCli": true,
+        "systemVars": false
+      },
+      "errors": {
+        "dev": true,
+        "deprecated": true
+      }
+    },
+    {
+      "name": "dev-mode",
+      "hidden": true,
+      "inherits": "cmake-pedantic",
+      "cacheVariables": {
+        "headeronly_DEVELOPER_MODE": "ON"
+      }
+    },
+    {
+      "name": "ci-std",
+      "description": "This preset makes sure the project actually builds with at least the specified standard",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_EXTENSIONS": "OFF",
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CXX_STANDARD_REQUIRED": "ON"
+      }
+    },
+    {
+      "name": "flags-gcc-clang",
+      "description": "These flags are supported by both GCC and Clang",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-D_GLIBCXX_ASSERTIONS=1 -fstack-protector-strong -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast",
+        "CMAKE_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen",
+        "CMAKE_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen"
+      }
+    },
+    {
+      "name": "flags-appleclang",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fstack-protector-strong -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast"
+      }
+    },
+    {
+      "name": "flags-msvc",
+      "description": "Note that all the flags after /W4 are required for MSVC to conform to the language standard",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /permissive- /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:lambda /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
+        "CMAKE_EXE_LINKER_FLAGS": "/machine:x64 /guard:cf"
+      }
+    },
+    {
+      "name": "ci-linux",
+      "description": "Includes fortification with the CMake default release flags",
+      "inherits": ["flags-gcc-clang", "ci-std"],
+      "generator": "Unix Makefiles",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_FLAGS_RELEASE": "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -O3 -DNDEBUG"
+      }
+    },
+    {
+      "name": "ci-darwin",
+      "inherits": ["flags-appleclang", "ci-std"],
+      "generator": "Xcode",
+      "hidden": true
+    },
+    {
+      "name": "ci-win64",
+      "inherits": ["flags-msvc", "ci-std"],
+      "generator": "Visual Studio 17 2022",
+      "architecture": "x64",
+      "hidden": true
+    },
+    {
+      "name": "coverage-linux",
+      "binaryDir": "${sourceDir}/build/coverage",
+      "inherits": "ci-linux",
+      "hidden": true,
+      "cacheVariables": {
+        "ENABLE_COVERAGE": "ON",
+        "CMAKE_BUILD_TYPE": "Coverage",
+        "CMAKE_CXX_FLAGS_COVERAGE": "-Og -g --coverage -fkeep-inline-functions -fkeep-static-functions",
+        "CMAKE_EXE_LINKER_FLAGS_COVERAGE": "--coverage",
+        "CMAKE_SHARED_LINKER_FLAGS_COVERAGE": "--coverage"
+      }
+    },
+    {
+      "name": "ci-build",
+      "binaryDir": "${sourceDir}/build",
+      "hidden": true
+    },
+    {
+      "name": "ci-multi-config",
+      "description": "Speed up multi-config generators by generating only one configuration instead of the defaults",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CONFIGURATION_TYPES": "Release"
+      }
+    },
+    {
+      "name": "ci-macos",
+      "inherits": ["ci-build", "ci-darwin", "dev-mode", "ci-multi-config"]
+    },
+    {
+      "name": "ci-ubuntu",
+      "inherits": ["ci-build", "ci-linux", "clang-tidy", "cppcheck", "dev-mode"]
+    },
+    {
+      "name": "ci-windows",
+      "inherits": ["ci-build", "ci-win64", "dev-mode", "ci-multi-config"]
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,7 +35,7 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_CXX_EXTENSIONS": "OFF",
-        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CXX_STANDARD": "20",
         "CMAKE_CXX_STANDARD_REQUIRED": "ON"
       }
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 2,
+  "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 14,
+    "minor": 15,
     "patch": 0
   },
   "configurePresets": [
@@ -121,7 +121,7 @@
     },
     {
       "name": "ci-ubuntu",
-      "inherits": ["ci-build", "ci-linux", "clang-tidy", "cppcheck", "dev-mode"]
+      "inherits": ["ci-build", "ci-linux", "dev-mode"]
     },
     {
       "name": "ci-windows",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,131 +1,41 @@
 {
-  "version": 6,
-  "cmakeMinimumRequired": {
-    "major": 3,
-    "minor": 15,
-    "patch": 0
-  },
-  "configurePresets": [
-    {
-      "name": "cmake-pedantic",
-      "hidden": true,
-      "warnings": {
-        "dev": true,
-        "deprecated": true,
-        "uninitialized": true,
-        "unusedCli": true,
-        "systemVars": false
-      },
-      "errors": {
-        "dev": true,
-        "deprecated": true
-      }
+    "version": 9,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 25,
+        "patch": 0
     },
-    {
-      "name": "dev-mode",
-      "hidden": true,
-      "inherits": "cmake-pedantic",
-      "cacheVariables": {
-        "headeronly_DEVELOPER_MODE": "ON"
-      }
-    },
-    {
-      "name": "ci-std",
-      "description": "This preset makes sure the project actually builds with at least the specified standard",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CXX_EXTENSIONS": "OFF",
-        "CMAKE_CXX_STANDARD": "20",
-        "CMAKE_CXX_STANDARD_REQUIRED": "ON"
-      }
-    },
-    {
-      "name": "flags-gcc-clang",
-      "description": "These flags are supported by both GCC and Clang",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-D_GLIBCXX_ASSERTIONS=1 -fstack-protector-strong -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast",
-        "CMAKE_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen",
-        "CMAKE_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen"
-      }
-    },
-    {
-      "name": "flags-appleclang",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fstack-protector-strong -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast"
-      }
-    },
-    {
-      "name": "flags-msvc",
-      "description": "Note that all the flags after /W4 are required for MSVC to conform to the language standard",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /permissive- /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:lambda /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
-        "CMAKE_EXE_LINKER_FLAGS": "/machine:x64 /guard:cf"
-      }
-    },
-    {
-      "name": "ci-linux",
-      "description": "Includes fortification with the CMake default release flags",
-      "inherits": ["flags-gcc-clang", "ci-std"],
-      "generator": "Unix Makefiles",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS_RELEASE": "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -O3 -DNDEBUG"
-      }
-    },
-    {
-      "name": "ci-darwin",
-      "inherits": ["flags-appleclang", "ci-std"],
-      "generator": "Xcode",
-      "hidden": true
-    },
-    {
-      "name": "ci-win64",
-      "inherits": ["flags-msvc", "ci-std"],
-      "generator": "Visual Studio 17 2022",
-      "architecture": "x64",
-      "hidden": true
-    },
-    {
-      "name": "coverage-linux",
-      "binaryDir": "${sourceDir}/build/coverage",
-      "inherits": "ci-linux",
-      "hidden": true,
-      "cacheVariables": {
-        "ENABLE_COVERAGE": "ON",
-        "CMAKE_BUILD_TYPE": "Coverage",
-        "CMAKE_CXX_FLAGS_COVERAGE": "-Og -g --coverage -fkeep-inline-functions -fkeep-static-functions",
-        "CMAKE_EXE_LINKER_FLAGS_COVERAGE": "--coverage",
-        "CMAKE_SHARED_LINKER_FLAGS_COVERAGE": "--coverage"
-      }
-    },
-    {
-      "name": "ci-build",
-      "binaryDir": "${sourceDir}/build",
-      "hidden": true
-    },
-    {
-      "name": "ci-multi-config",
-      "description": "Speed up multi-config generators by generating only one configuration instead of the defaults",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CONFIGURATION_TYPES": "Release"
-      }
-    },
-    {
-      "name": "ci-macos",
-      "inherits": ["ci-build", "ci-darwin", "dev-mode", "ci-multi-config"]
-    },
-    {
-      "name": "ci-ubuntu",
-      "inherits": ["ci-build", "ci-linux", "dev-mode"]
-    },
-    {
-      "name": "ci-windows",
-      "inherits": ["ci-build", "ci-win64", "dev-mode", "ci-multi-config"]
-    }
-  ]
+    "include": [
+        "cmake/CMake${hostSystemName}Presets.json"
+    ],
+    "buildPresets": [
+        {
+            "name": "debug",
+            "configurePreset": "default",
+            "configuration": "Debug"
+        },
+        {
+            "name": "release",
+            "configurePreset": "default",
+            "configuration": "Release"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "debug",
+            "configurePreset": "default",
+            "configuration": "Debug",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "release",
+            "configurePreset": "default",
+            "configuration": "Release",
+            "output": {
+                "outputOnFailure": true
+            }
+        }
+    ]
 }

--- a/cmake/CMakeCommonPresets.json
+++ b/cmake/CMakeCommonPresets.json
@@ -1,0 +1,56 @@
+{
+    "version": 9,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 30,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "cmake-pedantic",
+            "hidden": true,
+            "warnings": {
+                "dev": true,
+                "deprecated": true,
+                "uninitialized": true,
+                "unusedCli": true,
+                "systemVars": false
+            },
+            "errors": {
+                "dev": true,
+                "deprecated": true
+            }
+        },
+        {
+            "name": "dev-mode",
+            "hidden": true,
+            "inherits": "cmake-pedantic",
+            "cacheVariables": {
+                "GOALS_BUILD_TESTING": "ON"
+            }
+        },
+        {
+            "name": "ci-std",
+            "description": "This preset makes sure the project actually builds with at least the specified standard",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_EXTENSIONS": "OFF",
+                "CMAKE_CXX_STANDARD": "20",
+                "CMAKE_CXX_STANDARD_REQUIRED": "ON"
+            }
+        },
+        {
+            "name": "ci-build",
+            "binaryDir": "${sourceDir}/build",
+            "hidden": true
+        },
+        {
+            "name": "ci-multi-config",
+            "description": "Speed up multi-config generators by generating only one configuration instead of the defaults",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CONFIGURATION_TYPES": "Release"
+            }
+        }
+    ]
+}

--- a/cmake/CMakeDarwinPresets.json
+++ b/cmake/CMakeDarwinPresets.json
@@ -1,0 +1,44 @@
+{
+    "version": 9,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 30,
+        "patch": 0
+    },
+    "include": [
+        "CMakeCommonPresets.json"
+    ],
+    "configurePresets": [
+        {
+            "name": "flags-appleclang",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fstack-protector-strong -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast"
+            }
+        },
+        {
+            "name": "ci-darwin",
+            "inherits": [
+                "flags-appleclang",
+                "ci-std"
+            ],
+            "generator": "Xcode",
+            "hidden": true
+        },
+        {
+            "name": "default",
+            "inherits": [
+                "ci-build",
+                "ci-darwin",
+                "dev-mode"
+            ]
+        },
+        {
+            "name": "ci",
+            "inherits": [
+                "default",
+                "ci-multi-config"
+            ]
+        }
+    ]
+}

--- a/cmake/CMakeLinuxPresets.json
+++ b/cmake/CMakeLinuxPresets.json
@@ -1,0 +1,65 @@
+{
+    "version": 9,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 30,
+        "patch": 0
+    },
+    "include": [
+        "CMakeCommonPresets.json"
+    ],
+    "configurePresets": [
+        {
+            "name": "flags-gcc-clang",
+            "description": "These flags are supported by both GCC and Clang",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-D_GLIBCXX_ASSERTIONS=1 -fstack-protector-strong -fcf-protection=full -fstack-clash-protection -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast",
+                "CMAKE_EXE_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen",
+                "CMAKE_SHARED_LINKER_FLAGS": "-Wl,--allow-shlib-undefined,--as-needed,-z,noexecstack,-z,relro,-z,now,-z,nodlopen"
+            }
+        },
+        {
+            "name": "ci-linux",
+            "description": "Includes fortification with the CMake default release flags",
+            "inherits": [
+                "flags-gcc-clang",
+                "ci-std"
+            ],
+            "generator": "Ninja Multi-Config",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS_RELEASE": "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -O3 -DNDEBUG"
+            }
+        },
+        {
+            "name": "coverage",
+            "binaryDir": "${sourceDir}/build/coverage",
+            "inherits": "ci-linux",
+            "hidden": true,
+            "cacheVariables": {
+                "ENABLE_COVERAGE": "ON",
+                "CMAKE_BUILD_TYPE": "Coverage",
+                "CMAKE_CXX_FLAGS_COVERAGE": "-Og -g --coverage -fkeep-inline-functions -fkeep-static-functions",
+                "CMAKE_EXE_LINKER_FLAGS_COVERAGE": "--coverage",
+                "CMAKE_SHARED_LINKER_FLAGS_COVERAGE": "--coverage"
+            }
+        },
+        {
+            "name": "default",
+            "inherits": [
+                "ci-build",
+                "ci-linux",
+                "dev-mode"
+            ]
+        },
+        {
+            "name": "ci",
+            "inherits": [
+                "default",
+                "ci-multi-config"
+            ]
+        }
+    ]
+}

--- a/cmake/CMakeUserPresets.json
+++ b/cmake/CMakeUserPresets.json
@@ -1,0 +1,41 @@
+{
+    "version": 9,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 25,
+        "patch": 0
+    },
+    "include": [
+        "cmake/CMakeWindowsPresets.json"
+    ],
+    "buildPresets": [
+        {
+            "name": "vscode-debug",
+            "configurePreset": "default",
+            "configuration": "Debug"
+        },
+        {
+            "name": "vscode-release",
+            "configurePreset": "default",
+            "configuration": "Release"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "vscode-debug",
+            "configurePreset": "default",
+            "configuration": "Debug",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "vscode-release",
+            "configurePreset": "default",
+            "configuration": "Release",
+            "output": {
+                "outputOnFailure": true
+            }
+        }
+    ]
+}

--- a/cmake/CMakeWindowsPresets.json
+++ b/cmake/CMakeWindowsPresets.json
@@ -1,0 +1,47 @@
+{
+    "version": 9,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 30,
+        "patch": 0
+    },
+    "include": [
+        "CMakeCommonPresets.json"
+    ],
+    "configurePresets": [
+        {
+            "name": "flags-msvc",
+            "description": "Note that all the flags after /W4 are required for MSVC to conform to the language standard",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /permissive- /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:lambda /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
+                "CMAKE_EXE_LINKER_FLAGS": "/machine:x64 /guard:cf"
+            }
+        },
+        {
+            "name": "ci-win64",
+            "inherits": [
+                "flags-msvc",
+                "ci-std"
+            ],
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "hidden": true
+        },
+        {
+            "name": "default",
+            "inherits": [
+                "ci-build",
+                "ci-win64",
+                "dev-mode"
+            ]
+        },
+        {
+            "name": "ci",
+            "inherits": [
+                "default",
+                "ci-multi-config"
+            ]
+        }
+    ]
+}

--- a/include/DPData.h
+++ b/include/DPData.h
@@ -195,10 +195,10 @@ namespace DP {
 		inline void sti_prev(const int t, const int s, const int a, const int r, const double value) {_sti_prev[t][s][a][r] = value;}
 
 		inline double pwid_infection_force(const int t, const int s) const {return (*_pwid_infection_force)[t][s];}
-		inline void pwid_infection_force(const int t, const int s, const double value) {return (*_pwid_infection_force)[t][s] = value;}
+		inline void pwid_infection_force(const int t, const int s, const double value) {(*_pwid_infection_force)[t][s] = value;}
 
 		inline double pwid_needle_sharing(const int t) const {return (*_pwid_needle_sharing)[t];}
-		inline void pwid_needle_sharing(const int t, const double value) {return (*_pwid_needle_sharing)[t] = value;}
+		inline void pwid_needle_sharing(const int t, const double value) {(*_pwid_needle_sharing)[t] = value;}
 
 		inline double hiv_dist(const int s, const int a, const int h) const {return _hiv_dist[s][a][h];}
 		inline void hiv_dist(const int s, const int a, const int h, const double value) {_hiv_dist[s][a][h] = value;}

--- a/include/DPProjection_impl.h
+++ b/include/DPProjection_impl.h
@@ -919,8 +919,8 @@ namespace DP {
 		std::fill_n(uptake_rate.data(), uptake_rate.num_elements(), 0.0);
 
 		// Short-circuit uptake calculations if no one is on ART
-		if (dat.art_num_adult( t, DP::FEMALE) == 0.0 && dat.art_num_adult( t, DP::MALE) == 0.0 &&
-			  dat.art_prop_adult(t, DP::FEMALE) == 0.0 && dat.art_prop_adult(t, DP::MALE) == 0.0) {
+		if (GB::isZero(dat.art_num_adult( t, DP::FEMALE)) && GB::isZero(dat.art_num_adult( t, DP::MALE)) &&
+                GB::isZero(dat.art_prop_adult(t, DP::FEMALE)) && GB::isZero(dat.art_prop_adult(t, DP::MALE))) {
 			return;
 		}
 

--- a/include/GBUtil.h
+++ b/include/GBUtil.h
@@ -16,6 +16,9 @@ bool contains(const std::string &str, const std::string &sub);
 
 } // end namespace GB
 
+template <typename T>
+bool isZero(T x);
+
 #include <GBUtil_impl.h>
 
 #endif // GBUTIL_H

--- a/include/GBUtil_impl.h
+++ b/include/GBUtil_impl.h
@@ -19,7 +19,7 @@ bool contains(const std::string &str, const std::string &sub) {
   return str.find(sub) != std::string::npos;
 }
 
-// This is pretty gross but quality of floats raises an error as check will often
+// This is pretty gross but equality of floats raises an error as check will often
 // fail due to machine precision. Better to check with some epsilon. But we have
 // a special case here where something is initialized to 0.0, and
 // we want to check for exact equality to that, so an == 0.0 is appropriate

--- a/include/GBUtil_impl.h
+++ b/include/GBUtil_impl.h
@@ -19,6 +19,23 @@ bool contains(const std::string &str, const std::string &sub) {
   return str.find(sub) != std::string::npos;
 }
 
+// This is pretty gross but quality of floats raises an error as check will often
+// fail due to machine precision. Better to check with some epsilon. But we have
+// a special case here where something is initialized to 0.0, and
+// we want to check for exact equality to that, so an == 0.0 is appropriate
+// turn off the warnings for this single line.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma warning(push)
+#pragma warning(disable : 4723)
+template <typename T>
+bool isZero(T x) {
+    static_assert(std::is_floating_point<T>::value, "isZero can only be used with floating-point types.");
+    return x == 0;
+}
+#pragma warning(pop)
+#pragma GCC diagnostic pop
+
 } // end namespace GB
 
 #endif // GBUTIL_IMPL_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,8 @@ if(NOT Catch2_FOUND)
 else()
     message(STATUS "Catch2 found at ${Catch2_INCLUDE_DIRS}")
 endif()
+get_target_property(catch2_includes Catch2 INTERFACE_INCLUDE_DIRECTORIES)
+
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 
 file(GLOB TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
@@ -28,6 +30,7 @@ foreach(TEST_FILE ${TEST_SOURCES})
     get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
     file(RELATIVE_PATH FILE_NAME ${CMAKE_CURRENT_SOURCE_DIR} ${TEST_FILE})
     add_executable(${TEST_NAME} ${FILE_NAME})
+    target_include_directories(Catch2 SYSTEM INTERFACE ${catch2_includes})
     target_link_libraries(${TEST_NAME} PRIVATE GoalsARM Catch2::Catch2WithMain)
 endforeach()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,11 @@ foreach(TEST_FILE ${TEST_SOURCES})
     file(RELATIVE_PATH FILE_NAME ${CMAKE_CURRENT_SOURCE_DIR} ${TEST_FILE})
     add_executable(${TEST_NAME} ${FILE_NAME})
     target_include_directories(Catch2 SYSTEM INTERFACE ${catch2_includes})
+    # Suppress warnings for Catch2 when using MSVC
+    if (MSVC)
+        # Per-target suppression (better)
+        set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "/w")
+    endif() 
     target_link_libraries(${TEST_NAME} PRIVATE GoalsARM Catch2::Catch2WithMain)
 endforeach()
 


### PR DESCRIPTION
This PR will
* Run automated tests as part of CI on windows, linux and mac

This also sets some compiler flags via CMakePresets which turn on a few things. Got this set up from recommended https://github.com/friendlyanon/cmake-init/ for header only libraries. They look quite sensible, at the moment will only be used on CI. But it turns on a bunch of warnings, sets optimisation flags and source fortification and adds a bunch of security flags. You can use the presets locally using `cmake --preset ci-windows` or similar. We could add a preset for debug mode too.

I think it is worth taking a look at some of the warnings that are raised here and seeing if they are something we should fix.

