### PR TITLE
Fixed a few minor issues flagged by compile-time warnings (initialize…

### DIFF
--- a/include/DPData.h
+++ b/include/DPData.h
@@ -394,8 +394,8 @@ namespace DP {
 			_irr_pop(year_sex_pop_t(boost::extents[year_final - year_start + 1][DP::N_SEX][DP::N_POP])),
 
 			_partner_rate(NULL),
-			_partner_preference_age(NULL),
 			_partner_assortativity(NULL),
+			_partner_preference_age(NULL),
 
 			_condom_freq(year_bond_t(boost::extents[year_final - year_start + 1][DP::N_BOND])),
 
@@ -417,9 +417,9 @@ namespace DP {
 			_clhiv_agein(year_sex_hiv_dtx_t(boost::extents[year_final - year_start + 1][DP::N_SEX][DP::N_HIV][DP::N_DTX])),
 
 			_births(NULL),
-			_births_exposed(NULL),
 			_deaths(year_sex_age_t(boost::extents[year_final - year_start + 1][DP::N_SEX][DP::N_AGE])),
 			_popsize(year_sex_age_t(boost::extents[year_final - year_start + 1][DP::N_SEX][DP::N_AGE])),
+			_births_exposed(NULL),
 			_new_hiv_infections(NULL)
 	{
 		art_flow(DP::DTX_ART1, 2.0); // 6 months in 1st ART state [0,6)  months

--- a/include/DPProjection_impl.h
+++ b/include/DPProjection_impl.h
@@ -494,7 +494,7 @@ namespace DP {
 		dat.births(t, DP::FEMALE, births * perc_f);
 
 		// all newborn males are assumed uncircumcised
-		for (int u = DP::SEX_MIN; u <= DP::SEX_MAX; ++u) {
+		for (u = DP::SEX_MIN; u <= DP::SEX_MAX; ++u) {
 			surv = dat.Sx(t,u,0);
 			mort = 1.0 - surv;
 			pop.child_neg(t, u, 0) = dat.births(t,u) * surv;


### PR DESCRIPTION
GoalsARM throws quite a few warnings at compile-time. This addresses a couple of those, but does not (yet) address type mismatches from using signed time as an array index.
